### PR TITLE
Add verified Featured in section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 StructEval is a framework for evaluating language models on structured outputs, supporting rendering and evaluation of generated code. Our paper has been accepted by TMLR 2025.
 
+## Featured in
+
+- [Awesome AI Leaderboard](https://github.com/SAILResearch/awesome-ai-leaderboard)
+
 (**Note**: check the [litellm branch](https://github.com/TIGER-AI-Lab/StructEval/tree/litellm) as a more friendly cli to evaluate more latest models.)
 
 ## Installation


### PR DESCRIPTION
## Summary

Adds a small `Featured in` section for verified upstream inclusions, starting with Awesome AI Leaderboard.

The inclusion is merged and present on the upstream default branch: https://github.com/SAILResearch/awesome-ai-leaderboard/pull/92

Future verified merges can be appended to this same section.

This pull request was prepared with assistance from OpenAI Codex and manually reviewed. No co-author trailer is included.